### PR TITLE
Chm-2: Fix machine status not updating correctly

### DIFF
--- a/.github/workflows/build_chat_ui_manager.yml
+++ b/.github/workflows/build_chat_ui_manager.yml
@@ -7,7 +7,7 @@ on:
       - ".github/workflows/build_chat_ui_manager.yml"
     branches:
       - "main"
-      - "chm-1-create-chat-ui-manager-app"
+      - "chm-2-fix-machine-status-not-updated-correctly"
     tags:
       - "v*"
   pull_request:

--- a/chat-ui-manager-app/src/routes/+page.svelte
+++ b/chat-ui-manager-app/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 
 	const chatUIUrl = env.PUBLIC_CHAT_UI_URL;
 	const chatUIDelayMs = Number(env.PUBLIC_CHAT_UI_DELAY_SEC) * 1000 || 30_000; // Default to 30 seconds if not set
+	const pollStatusIntervalMs = 5000; // 5 seconds
 
 	let machineStatus: MachineStatus = $state(MachineStatus.UNKNOWN);
 	let chatUIAvailable = $state(false);
@@ -19,6 +20,27 @@
 			console.log('Fetch aborted');
 		};
 	});
+
+	// Poll /api/vm/status until status is RUNNING or STOPPED.
+	async function pollStatusUntilFinal(interval: number): Promise<MachineStatus> {
+		return new Promise((resolve, reject) => {
+			const timer = setInterval(async () => {
+				try {
+					const res = await fetch('/api/vm/status');
+					if (!res.ok) throw new Error('Failed to fetch status');
+					const { status } = await res.json();
+					machineStatus = status;
+					if (status === MachineStatus.RUNNING || status === MachineStatus.STOPPED) {
+						clearInterval(timer);
+						resolve(status);
+					}
+				} catch (err) {
+					clearInterval(timer);
+					reject(err);
+				}
+			}, interval);
+		});
+	}
 
 	async function checkMachineStatus(signal?: AbortSignal) {
 		try {
@@ -53,10 +75,11 @@
 		try {
 			const res = await fetch('/api/vm/start', { method: 'POST' });
 			if (!res.ok) throw new Error('Failed to start machine');
-			const data = await res.json();
-			machineStatus = data.status; // E.g. MachineStatus.RUNNING
+			const { status } = await res.json();
+			machineStatus = status; // E.g. MachineStatus.STARTING
 
-			if (machineStatus === MachineStatus.RUNNING) {
+			const final = await pollStatusUntilFinal(pollStatusIntervalMs);
+			if (final === MachineStatus.RUNNING) {
 				setChatUIDelay(chatUIDelayMs); // Once the machine is running, set the delay
 			}
 		} catch (err) {
@@ -71,8 +94,9 @@
 		try {
 			const res = await fetch('/api/vm/stop', { method: 'POST' });
 			if (!res.ok) throw new Error('Failed to stop machine');
-			const data = await res.json();
-			machineStatus = data.status; // E.g. MachineStatus.STOPPED
+			const { status } = await res.json();
+			machineStatus = status; // E.g. MachineStatus.STOPPING
+			await pollStatusUntilFinal(pollStatusIntervalMs); // Wait for the machine to stop
 		} catch (err) {
 			console.error(err);
 			machineStatus = MachineStatus.RUNNING; // Revert if it fails

--- a/chat-ui-manager-app/src/routes/+page.svelte
+++ b/chat-ui-manager-app/src/routes/+page.svelte
@@ -6,9 +6,13 @@
 	const chatUIUrl = env.PUBLIC_CHAT_UI_URL;
 	const chatUIDelayMs = Number(env.PUBLIC_CHAT_UI_DELAY_SEC) * 1000 || 30_000; // Default to 30 seconds if not set
 	const pollStatusIntervalMs = 5000; // 5 seconds
+	const maxPollAttempts = 36; // 5 * 36 = 3 minutes
 
 	let machineStatus: MachineStatus = $state(MachineStatus.UNKNOWN);
 	let chatUIAvailable = $state(false);
+
+	// Controller to cancel polling if needed
+	let pollController: AbortController;
 
 	onMount(() => {
 		const controller = new AbortController();
@@ -17,28 +21,39 @@
 		// Cleanup function to abort the fetch request when the component is destroyed
 		return () => {
 			controller.abort();
-			console.log('Fetch aborted');
 		};
 	});
 
-	// Poll /api/vm/status until status is RUNNING or STOPPED.
-	async function pollStatusUntilFinal(interval: number): Promise<MachineStatus> {
+	// Poll for the VM's status until it is RUNNING/STOPPED, reached max attempts, or if aborted via signal.
+	async function pollStatusUntilFinal(signal?: AbortSignal): Promise<MachineStatus> {
 		return new Promise((resolve, reject) => {
+			let attempts = 0;
 			const timer = setInterval(async () => {
+				// Abort if signaled
+				if (signal?.aborted) {
+					clearInterval(timer);
+					return reject(new Error('Polling aborted'));
+				}
+				attempts++;
 				try {
-					const res = await fetch('/api/vm/status');
-					if (!res.ok) throw new Error('Failed to fetch status');
-					const { status } = await res.json();
-					machineStatus = status;
-					if (status === MachineStatus.RUNNING || status === MachineStatus.STOPPED) {
+					await checkMachineStatus(signal);
+					if (machineStatus === MachineStatus.RUNNING || machineStatus === MachineStatus.STOPPED) {
 						clearInterval(timer);
-						resolve(status);
+						return resolve(machineStatus); // Resolve with the current machineStatus
+					}
+					if (attempts >= maxPollAttempts) {
+						clearInterval(timer);
+						return reject(new Error('Polling timed out'));
 					}
 				} catch (err) {
 					clearInterval(timer);
-					reject(err);
+					return reject(err);
 				}
-			}, interval);
+			}, pollStatusIntervalMs);
+			signal?.addEventListener('abort', () => {
+				clearInterval(timer);
+				reject(new Error('Polling aborted'));
+			});
 		});
 	}
 
@@ -73,18 +88,20 @@
 	async function startMachine() {
 		machineStatus = MachineStatus.STARTING;
 		try {
+			pollController = new AbortController();
 			const res = await fetch('/api/vm/start', { method: 'POST' });
 			if (!res.ok) throw new Error('Failed to start machine');
 			const { status } = await res.json();
 			machineStatus = status; // E.g. MachineStatus.STARTING
 
-			const final = await pollStatusUntilFinal(pollStatusIntervalMs);
+			const final = await pollStatusUntilFinal(pollController.signal);
 			if (final === MachineStatus.RUNNING) {
 				setChatUIDelay(chatUIDelayMs); // Once the machine is running, set the delay
 			}
 		} catch (err) {
 			console.error(err);
-			machineStatus = MachineStatus.STOPPED; // Revert if it fails
+			pollController?.abort();
+			machineStatus = MachineStatus.STOPPED;
 		}
 	}
 
@@ -92,14 +109,16 @@
 		machineStatus = MachineStatus.STOPPING;
 		chatUIAvailable = false; // Reset availability of the Chat-UI page when stopping the VM
 		try {
+			pollController = new AbortController();
 			const res = await fetch('/api/vm/stop', { method: 'POST' });
 			if (!res.ok) throw new Error('Failed to stop machine');
 			const { status } = await res.json();
 			machineStatus = status; // E.g. MachineStatus.STOPPING
-			await pollStatusUntilFinal(pollStatusIntervalMs); // Wait for the machine to stop
+			await pollStatusUntilFinal(pollController.signal); // Wait for the machine to stop
 		} catch (err) {
 			console.error(err);
-			machineStatus = MachineStatus.RUNNING; // Revert if it fails
+			pollController?.abort();
+			machineStatus = MachineStatus.RUNNING;
 			chatUIAvailable = true; // Reset availability of the Chat-UI page
 		}
 	}

--- a/chat-ui-manager-app/src/routes/api/vm/start/+server.ts
+++ b/chat-ui-manager-app/src/routes/api/vm/start/+server.ts
@@ -16,8 +16,8 @@ const computeClient = new ComputeManagementClient(credential, subscriptionId);
 
 export const POST: RequestHandler = async () => {
 	try {
-		await computeClient.virtualMachines.beginStartAndWait(resourceGroupName, vmName);
-		return json({ status: MachineStatus.RUNNING });
+		await computeClient.virtualMachines.beginStart(resourceGroupName, vmName);
+		return json({ status: MachineStatus.STARTING });
 	} catch (error) {
 		console.error('Error starting VM:', error);
 		return json({ status: MachineStatus.STOPPED, error: 'Could not start VM' }, { status: 500 });

--- a/chat-ui-manager-app/src/routes/api/vm/stop/+server.ts
+++ b/chat-ui-manager-app/src/routes/api/vm/stop/+server.ts
@@ -16,8 +16,8 @@ const computeClient = new ComputeManagementClient(credential, subscriptionId);
 
 export const POST: RequestHandler = async () => {
 	try {
-		await computeClient.virtualMachines.beginDeallocateAndWait(resourceGroupName, vmName);
-		return json({ status: MachineStatus.STOPPED });
+		await computeClient.virtualMachines.beginDeallocate(resourceGroupName, vmName);
+		return json({ status: MachineStatus.STOPPING });
 	} catch (error) {
 		console.error('Error stopping VM:', error);
 		return json({ status: MachineStatus.RUNNING, error: 'Could not stop VM' }, { status: 500 });


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refactor virtual machine (VM) management to improve status reporting by updating API endpoints to return immediate intermediate statuses and implementing a client-side polling mechanism. Introduce a <code>pollStatusUntilFinal</code> function in the UI to asynchronously track VM state transitions until a final <code>RUNNING</code> or <code>STOPPED</code> status is achieved.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/chat-ui-manager/2?tool=ast&topic=VM+Status+Polling>VM Status Polling</a>
        </td><td>Implement a client-side polling mechanism, <code>pollStatusUntilFinal</code>, to continuously check the virtual machine's status until it transitions to a final <code>MachineStatus.RUNNING</code> or <code>MachineStatus.STOPPED</code> state, and modify the <code>startMachine</code> and <code>stopMachine</code> functions to utilize this polling.<details><summary>Modified files (1)</summary><ul><li>chat-ui-manager-app/src/routes/+page.svelte</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ddishi</td><td>Chm-1-Create-ChatUI-Ma...</td><td>April 03, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/chat-ui-manager/2?tool=ast&topic=CI+Workflow+Update>CI Workflow Update</a>
        </td><td>Update the GitHub Actions workflow configuration to reflect a new branch name for triggering builds.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/build_chat_ui_manager.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ddishi</td><td>Chm-1-Create-ChatUI-Ma...</td><td>April 03, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/chat-ui-manager/2?tool=ast&topic=API+Status+Updates>API Status Updates</a>
        </td><td>Update the VM management API endpoints, <code>/api/vm/start</code> and <code>/api/vm/stop</code>, to return immediate intermediate statuses (<code>MachineStatus.STARTING</code> and <code>MachineStatus.STOPPING</code>) instead of waiting for the full operation to complete.<details><summary>Modified files (2)</summary><ul><li>chat-ui-manager-app/src/routes/api/vm/stop/+server.ts</li>
<li>chat-ui-manager-app/src/routes/api/vm/start/+server.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ddishi</td><td>Chm-1-Create-ChatUI-Ma...</td><td>April 03, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/Hirundo-io/chat-ui-manager/2?tool=ast>(Baz)</a>.